### PR TITLE
Cross-platform npm scripts using cross-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.7.0",
   "description": "rrweb's component to take a snapshot of DOM, aka DOM serializer",
   "scripts": {
-    "test": "TS_NODE_CACHE=false TS_NODE_FILES=true mocha -r ts-node/register test/**/*.ts",
+    "test": "cross-env TS_NODE_CACHE=false TS_NODE_FILES=true mocha -r ts-node/register test/**/*.ts",
     "bundle": "rollup --config"
   },
   "repository": {
@@ -38,6 +38,7 @@
     "@types/node": "^10.11.3",
     "@types/puppeteer": "^1.8.0",
     "chai": "^4.1.2",
+    "cross-env": "^5.2.0",
     "jest-snapshot": "^23.6.0",
     "mocha": "^5.2.0",
     "puppeteer": "^1.10.0",


### PR DESCRIPTION
Added `cross-env` in the same way as in https://github.com/rrweb-io/rrweb/pull/17.

`npm test` completes successfully on Windows 10 now.