### PR TITLE
Fixed detection of multiple consecutive CSS URLs without quotes

### DIFF
--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -42,11 +42,12 @@ function extractOrigin(url: string): string {
   return origin;
 }
 
-const URL_IN_CSS_REF = /url\((['"]|)([^'"]*)\1\)/gm;
+const URL_IN_CSS_REF = /url\((?:'([^']*)'|"([^"]*)"|([^)]*))\)/gm;
 const RELATIVE_PATH = /^(?!www\.|(?:http|ftp)s?:\/\/|[A-Za-z]:\\|\/\/).*/;
 const DATA_URI = /^(data:)([\w\/\+]+);(charset=[\w-]+|base64).*,(.*)/gi;
 export function absoluteToStylesheet(cssText: string, href: string): string {
-  return cssText.replace(URL_IN_CSS_REF, (_1, _2, filePath) => {
+  return cssText.replace(URL_IN_CSS_REF, (_1, path1, path2, path3) => {
+    const filePath = path1 || path2 || path3;
     if (!RELATIVE_PATH.test(filePath)) {
       return `url('${filePath}')`;
     }

--- a/test/snapshot.test.ts
+++ b/test/snapshot.test.ts
@@ -47,6 +47,12 @@ describe('absolute url to stylesheet', () => {
     );
   });
 
+  it('can handle multiple no quote paths', () => {
+    expect(absoluteToStylesheet('background-image: url(images/b.jpg); background: #aabbcc url(images/a.jpg) 50% 50% repeat;', href)).to.equal(
+      `background-image: url('http://localhost/css/images/b.jpg'); background: #aabbcc url('http://localhost/css/images/a.jpg') 50% 50% repeat;`,
+    );
+  });
+
   it('can handle data url image', () => {
     expect(
       absoluteToStylesheet('url(data:image/gif;base64,ABC)', href),


### PR DESCRIPTION
Encountered a bug where if CSS URLs do not use quotes and there's more to match on the current line, the absolute URL might include some CSS code.

Fixed the regex to account for this case, and added testcase.