### PR TITLE
Parse style attributes for absolute URL paths

### DIFF
--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -105,6 +105,8 @@ function serializeNode(n: Node, doc: Document): serializedNode | false {
         // relative path in attribute
         if (name === 'src' || name === 'href') {
           attributes[name] = absoluteToDoc(doc, value);
+        } else if (name === 'style') {
+          attributes[name] = absoluteToStylesheet(value, doc.location.href);
         } else {
           attributes[name] = value;
         }


### PR DESCRIPTION
Style attributes might contain URL's, for example a background image. This change uses the existing stylesheet parsing code to handle style attributes, ensuring any URL's within them are made absolute.