### PR TITLE
Make block css class optional & fix test

### DIFF
--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -83,8 +83,11 @@ function isSVGElement(el: Element): boolean {
   return el.tagName === 'svg' || el instanceof SVGElement;
 }
 
-const BLOCK_CLASS = 'rr-block';
-function serializeNode(n: Node, doc: Document): serializedNode | false {
+function serializeNode(
+  n: Node,
+  doc: Document,
+  blockClass: string,
+): serializedNode | false {
   switch (n.nodeType) {
     case n.DOCUMENT_NODE:
       return {
@@ -99,7 +102,7 @@ function serializeNode(n: Node, doc: Document): serializedNode | false {
         systemId: (n as DocumentType).systemId,
       };
     case n.ELEMENT_NODE:
-      const needBlock = (n as HTMLElement).classList.contains(BLOCK_CLASS);
+      const needBlock = (n as HTMLElement).classList.contains(blockClass);
       const tagName = (n as HTMLElement).tagName.toLowerCase();
       let attributes: attributes = {};
       for (const { name, value } of Array.from((n as HTMLElement).attributes)) {
@@ -197,9 +200,10 @@ export function serializeNodeWithId(
   n: Node,
   doc: Document,
   map: idNodeMap,
+  blockClass: string,
   skipChild = false,
 ): serializedNodeWithId | null {
-  const _serializedNode = serializeNode(n, doc);
+  const _serializedNode = serializeNode(n, doc, blockClass);
   if (!_serializedNode) {
     // TODO: dev only
     console.warn(n, 'not serialized');
@@ -222,7 +226,12 @@ export function serializeNodeWithId(
     recordChild
   ) {
     for (const childN of Array.from(n.childNodes)) {
-      const serializedChildNode = serializeNodeWithId(childN, doc, map);
+      const serializedChildNode = serializeNodeWithId(
+        childN,
+        doc,
+        map,
+        blockClass,
+      );
       if (serializedChildNode) {
         serializedNode.childNodes.push(serializedChildNode);
       }
@@ -231,10 +240,13 @@ export function serializeNodeWithId(
   return serializedNode;
 }
 
-function snapshot(n: Document): [serializedNodeWithId | null, idNodeMap] {
+function snapshot(
+  n: Document,
+  blockClass = 'rr-block',
+): [serializedNodeWithId | null, idNodeMap] {
   resetId();
   const idNodeMap: idNodeMap = {};
-  return [serializeNodeWithId(n, n, idNodeMap), idNodeMap];
+  return [serializeNodeWithId(n, n, idNodeMap, blockClass), idNodeMap];
 }
 
 export default snapshot;

--- a/test/snapshot.test.ts
+++ b/test/snapshot.test.ts
@@ -50,7 +50,7 @@ describe('absolute url to stylesheet', () => {
   it('can handle multiple no quote paths', () => {
     expect(
       absoluteToStylesheet(
-        'background-image: url(images/b.jpg); background: #aabbcc url(images/a.jpg) 50% 50% repeat;',
+        'background-image: url(images/b.jpg);background: #aabbcc url(images/a.jpg) 50% 50% repeat;',
         href,
       ),
     ).to.equal(


### PR DESCRIPTION
This allows a passing of a `blockClass` parameter to the `snapshot` function, it will default to `rr-block` if none is provided.

I have also fixed a broken spec by adding a class in the expected string.

This PR will fail until the above PR is merged. I can then bump the version in this package