### PR TITLE
Fixed missing space causing test to fail

### DIFF
--- a/test/snapshot.test.ts
+++ b/test/snapshot.test.ts
@@ -54,7 +54,7 @@ describe('absolute url to stylesheet', () => {
         href,
       ),
     ).to.equal(
-      `background-image: url('http://localhost/css/images/b.jpg');` +
+      `background-image: url('http://localhost/css/images/b.jpg'); ` +
         `background: #aabbcc url('http://localhost/css/images/a.jpg') 50% 50% repeat;`,
     );
   });


### PR DESCRIPTION
7c275cbf2cf86505cd9ad8a30e2782a4c7d3492f broke one of the tests because of a missing space. This pull requests corrects that issue.