### PR TITLE
reuse serialized nodes ids

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import snapshot, { serializeNodeWithId, resetId } from './snapshot';
+import snapshot, { serializeNodeWithId } from './snapshot';
 import rebuild, { buildNodeWithSN } from './rebuild';
 export * from './types';
 
-export { snapshot, serializeNodeWithId, resetId, rebuild, buildNodeWithSN };
+export { snapshot, serializeNodeWithId, rebuild, buildNodeWithSN };

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -13,10 +13,6 @@ function genId(): number {
   return _id++;
 }
 
-export function resetId() {
-  _id = 1;
-}
-
 function getCssRulesString(s: CSSStyleSheet): string | null {
   try {
     const rules = s.rules || s.cssRules;
@@ -252,11 +248,17 @@ export function serializeNodeWithId(
     console.warn(n, 'not serialized');
     return null;
   }
-  const serializedNode = Object.assign(_serializedNode, {
-    id: genId(),
-  });
-  (n as INode).__sn = serializedNode;
-  map[serializedNode.id] = n as INode;
+  const nAsINode = n as INode
+  let id
+  // Try to reuse the previous id
+  if (nAsINode.__sn) {
+    id = nAsINode.__sn.id
+  } else {
+    id = genId()
+  }
+  const serializedNode = Object.assign(_serializedNode, { id });
+  nAsINode.__sn = serializedNode;
+  map[id] = n as INode;
   let recordChild = !skipChild;
   if (serializedNode.type === NodeType.Element) {
     recordChild = recordChild && !serializedNode.needBlock;
@@ -290,7 +292,6 @@ function snapshot(
   blockClass: string | RegExp = 'rr-block',
   inlineStylesheet = true,
 ): [serializedNodeWithId | null, idNodeMap] {
-  resetId();
   const idNodeMap: idNodeMap = {};
   return [
     serializeNodeWithId(n, n, idNodeMap, blockClass, false, inlineStylesheet),

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -235,7 +235,7 @@ function serializeNode(
 }
 
 export function serializeNodeWithId(
-  n: Node,
+  n: Node | INode,
   doc: Document,
   map: idNodeMap,
   blockClass: string | RegExp,
@@ -248,17 +248,16 @@ export function serializeNodeWithId(
     console.warn(n, 'not serialized');
     return null;
   }
-  const nAsINode = n as INode
   let id
   // Try to reuse the previous id
-  if (nAsINode.__sn) {
-    id = nAsINode.__sn.id
+  if ('__sn' in n) {
+    id = n.__sn.id
   } else {
     id = genId()
   }
   const serializedNode = Object.assign(_serializedNode, { id });
-  nAsINode.__sn = serializedNode;
-  map[id] = n as INode;
+  (n as INode).__sn = serializedNode;
+  map[id] = (n as INode);
   let recordChild = !skipChild;
   if (serializedNode.type === NodeType.Element) {
     recordChild = recordChild && !serializedNode.needBlock;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,4 +1,4 @@
-import snapshot, { serializeNodeWithId, resetId } from './snapshot';
+import snapshot, { serializeNodeWithId } from './snapshot';
 import rebuild, { buildNodeWithSN } from './rebuild';
 export * from './types';
-export { snapshot, serializeNodeWithId, resetId, rebuild, buildNodeWithSN };
+export { snapshot, serializeNodeWithId, rebuild, buildNodeWithSN };

--- a/typings/snapshot.d.ts
+++ b/typings/snapshot.d.ts
@@ -1,6 +1,5 @@
-import { serializedNodeWithId, idNodeMap } from './types';
-export declare function resetId(): void;
+import { serializedNodeWithId, INode, idNodeMap } from './types';
 export declare function absoluteToStylesheet(cssText: string, href: string): string;
-export declare function serializeNodeWithId(n: Node, doc: Document, map: idNodeMap, blockClass: string | RegExp, skipChild?: boolean, inlineStylesheet?: boolean): serializedNodeWithId | null;
+export declare function serializeNodeWithId(n: Node | INode, doc: Document, map: idNodeMap, blockClass: string | RegExp, skipChild?: boolean, inlineStylesheet?: boolean): serializedNodeWithId | null;
 declare function snapshot(n: Document, blockClass?: string | RegExp, inlineStylesheet?: boolean): [serializedNodeWithId | null, idNodeMap];
 export default snapshot;


### PR DESCRIPTION
With this patch, each DOM node keeps its id during its existence. This allows to apply RRWeb events to previous snapshots if needed.

`resetId` has been removed because it loses its meaning: calling it would not reset the existing nodes ids anymore, only the new ones.

Since we don't reset the id anymore, we may exhaust the available ids quicker, but Number.MAX_SAFE_INTEGER (2 ** 53 - 1) is pretty large, so I doubt this'll cause any problem.

## Context

I would like to keep only the last N seconds of a recorded session. By using the `checkoutEveryNms` option, I get snapshots periodically, which is fine: I just have to save the events starting from the snapshot taken N seconds ago. But this means storing all intermediary snapshots until the end of the session.

To reduce the session memory consumption, I'd like to skip the intermediary snapshots, storing only incremental events. By reusing the serialized node ids, the incremental events can be applied on the base snapshot.