### PR TITLE
Allow rendering image tags inside svgs during replay

### DIFF
--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -109,7 +109,11 @@ function buildNode(n: serializedNodeWithId, doc: Document): Node | null {
             continue;
           }
           try {
-            node.setAttribute(name, value);
+            if (n.isSVG && name === 'xlink:href') {
+              node.setAttributeNS('http://www.w3.org/1999/xlink', name, value);
+            } else {
+              node.setAttribute(name, value);
+            }
           } catch (error) {
             // skip invalid attribute
           }


### PR DESCRIPTION
Currently, SVGs of the following form are not rendered, even though the rebuilt DOM is correct.

`<svg width="200" height="200"
        xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
  <image xlink:href="https://mdn.mozillademos.org/files/6457/mdn_logo_only_color.png" height="200" width="200"/>
</svg>`

The additional check when rebuilding attributes allows correct rendering of SVG elements containing `<image>` tags