### PR TITLE
Ignore broken CSS

### DIFF
--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -58,7 +58,7 @@ function getTagName(n: elementNode): string {
 
 const HOVER_SELECTOR = /([^\\]):hover/g;
 export function addHoverClass(cssText: string): string {
-  const ast = parse(cssText);
+  const ast = parse(cssText, {silent: true});
   if (!ast.stylesheet) {
     return cssText;
   }


### PR DESCRIPTION
Broken CSS inside a page will throw an error on our behalf. This should
be ignored because we are not in control of the CSS on the page we are
recording.