### PR TITLE
Greyed out blocked classes

### DIFF
--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -152,6 +152,9 @@ function buildNode(
           if (name === 'rr_height') {
             (node as HTMLElement).style.height = value;
           }
+          if (name === 'rr_background') {
+            (node as HTMLElement).style.background = value;
+          }
           if (name === 'rr_mediaState') {
             switch (value) {
               case 'played':

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -269,6 +269,7 @@ function serializeNode(
         const { width, height } = (n as HTMLElement).getBoundingClientRect();
         attributes.rr_width = `${width}px`;
         attributes.rr_height = `${height}px`;
+        attributes.rr_background = 'grey';
       }
       return {
         type: NodeType.Element,

--- a/test/__snapshots__/integration.ts.snap
+++ b/test/__snapshots__/integration.ts.snap
@@ -66,10 +66,10 @@ exports[`[html file]: block-element.html 1`] = `
       }
     </style>
   </head>  <body>
-    <div class=\\"rr-block big\\" style=\\"width: 50px; height: 50px;\\"></div>
+    <div class=\\"rr-block big\\" style=\\"width: 50px; height: 50px; background: grey;\\"></div>
     <div>record 2</div>
-    <div class=\\"rr-block small\\" style=\\"width: 50px; height: 100px;\\"></div>
-    <div class=\\"rr-block\\" style=\\"height: 200px; width: 100px\\"></div>
+    <div class=\\"rr-block small\\" style=\\"width: 50px; height: 100px; background: grey;\\"></div>
+    <div class=\\"rr-block\\" style=\\"height: 200px; width: 100px; background: grey;\\"></div>
   </body></html>"
 `;
 


### PR DESCRIPTION
This is to make the blocked classes greyed out in the replay to not give the impression that the website is broken during replay.