### PR TITLE
H tags

### DIFF
--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -8,7 +8,7 @@ import {
 } from './types';
 
 let _id = 1;
-const symbolAndNumberRegex = RegExp('[^a-z]');
+const symbolAndNumberRegex = RegExp('[^a-z1-6]');
 
 function genId(): number {
   return _id++;

--- a/test/__snapshots__/integration.ts.snap
+++ b/test/__snapshots__/integration.ts.snap
@@ -185,8 +185,8 @@ exports[`[html file]: invalid-tagname.html 1`] = `
 <body>
   <div>Hello</div>
   <div>Hello</div>
-  <div>Hello</div>
-  <div></div></body></html>"
+  <div></div>
+</body></html>"
 `;
 
 exports[`[html file]: picture.html 1`] = `
@@ -223,7 +223,7 @@ exports[`[html file]: with-relative-res.html 1`] = `
 <body>
   <a href=\\"http://localhost:3030/basic.html\\"></a>
   <div>Hello</div>
-  <div>Hello</div>
+  <alt34>Hello</alt34>
   <div>Hello</div>
   <div></div>
   <img src=\\"http://localhost:3030/a.jpg\\" alt=\\"\\" srcset=\\"\\" />

--- a/test/__snapshots__/integration.ts.snap
+++ b/test/__snapshots__/integration.ts.snap
@@ -45,7 +45,8 @@ exports[`[html file]: basic.html 1`] = `
   <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\" />
   <meta http-equiv=\\"X-UA-Compatible\\" content=\\"ie=edge\\" />
   <title>Document</title>
-</head><body></body></html>"
+</head><body>
+  <h1>Title</h1></body></html>"
 `;
 
 exports[`[html file]: block-element.html 1`] = `

--- a/test/html/basic.html
+++ b/test/html/basic.html
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-
+  <h1>Title</h1>
 </body>
 
 </html>

--- a/test/html/invalid-tagname.html
+++ b/test/html/invalid-tagname.html
@@ -8,7 +8,6 @@
 </head>
 <body>
   <alt="">Hello</alt="">
-  <alt34>Hello</alt34>
   <d123-_+!@#$%^&*()>Hello</d123-_+!@#$%^&*()>
   <ale#></ale#>
 </body>


### PR DESCRIPTION
In my use of the rr-web package I've had some issues where CSS selectors have specifically targeted h1-6 elements. This has broken the rendering of the replay. The current sanitisation of element names doesn't permit numbers, however from what I can see it's *only* h1-6 that are valid HTML elements that contain numbers. 

This PR naively allows numbers in the element names, asnd updates to tests to both test the function and handle it in `invalid-tagname` and `with-relative-res`. Given this allows invalid HTML to be snapshotted it may not be the right approach, but it was the least intrusive option without explcitly stating (and maintaining) which element names are valid. 