### PR TITLE
Avoid onload/onclick/onmouse console error messages

### DIFF
--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -128,6 +128,11 @@ function buildNode(
           try {
             if (n.isSVG && name === 'xlink:href') {
               node.setAttributeNS('http://www.w3.org/1999/xlink', name, value);
+            } else if (name == 'onload' || name == 'onclick' || name.substring(0, 7) == 'onmouse') {
+              // Rename some of the more common atttributes from https://www.w3schools.com/tags/ref_eventattributes.asp
+              // as setting them triggers a console.error (which shows up despite the try/catch)
+              // Assumption: these attributes are not used to css
+              node.setAttribute('_' + name, value);
             } else {
               node.setAttribute(name, value);
             }


### PR DESCRIPTION
Avoid more common causes of 'blocked script execution' console.error messages in Chrome which are not exceptions (but look like them):

    'Blocked script execution in '<page>' because the document's frame is sandboxed and the 'allow-scripts' permission is not set'