### PR TITLE
Add a `slimDOM` option to strip out unnecessary parts of the DOM

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import snapshot, {
   serializeNodeWithId,
   transformAttribute,
   visitSnapshot,
+  IGNORED_NODE,
 } from './snapshot';
 import rebuild, { buildNodeWithSN, addHoverClass } from './rebuild';
 export * from './types';
@@ -14,4 +15,5 @@ export {
   addHoverClass,
   transformAttribute,
   visitSnapshot,
+  IGNORED_NODE,
 };

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -332,6 +332,7 @@ export function serializeNodeWithId(
   inlineStylesheet = true,
   maskInputOptions?: MaskInputOptions,
   recordCanvas?: boolean,
+  slimDOM = false,
 ): serializedNodeWithId | null {
   const _serializedNode = serializeNode(
     n,
@@ -345,7 +346,12 @@ export function serializeNodeWithId(
     // TODO: dev only
     console.warn(n, 'not serialized');
     return null;
+  } else if (slimDOM &&
+      ((_serializedNode.type === NodeType.Element && _serializedNode.tagName == 'script')
+       || _serializedNode.type === NodeType.Comment)) {
+    return null;
   }
+
   let id;
   // Try to reuse the previous id
   if ('__sn' in n) {
@@ -377,6 +383,7 @@ export function serializeNodeWithId(
         inlineStylesheet,
         maskInputOptions,
         recordCanvas,
+        slimDOM,
       );
       if (serializedChildNode) {
         serializedNode.childNodes.push(serializedChildNode);
@@ -392,6 +399,7 @@ function snapshot(
   inlineStylesheet = true,
   maskAllInputsOrOptions: boolean | MaskInputOptions,
   recordCanvas?: boolean,
+  slimDOM = false,
 ): [serializedNodeWithId | null, idNodeMap] {
   const idNodeMap: idNodeMap = {};
   const maskInputOptions: MaskInputOptions =
@@ -426,6 +434,7 @@ function snapshot(
       inlineStylesheet,
       maskInputOptions,
       recordCanvas,
+      slimDOM,
     ),
     idNodeMap,
   ];

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -357,6 +357,7 @@ export function serializeNodeWithId(
     id = n.__sn.id;
   } else if (slimDOM && (
     (_serializedNode.type === NodeType.Element && _serializedNode.tagName == 'script')
+      || (_serializedNode.type === NodeType.Element && _serializedNode.tagName == 'link' && _serializedNode.attributes.rel == 'preload' && _serializedNode.attributes['as'] == 'script')
       || _serializedNode.type === NodeType.Comment
       || (!preserveWhiteSpace &&
           _serializedNode.type === NodeType.Text &&

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -349,6 +349,7 @@ export function serializeNodeWithId(
   } else if (slimDOM &&
       ((_serializedNode.type === NodeType.Element && _serializedNode.tagName == 'script')
        || _serializedNode.type === NodeType.Comment)) {
+    (n as INode).__sn = {id: -2, ignored: true};
     return null;
   }
 

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -346,22 +346,24 @@ export function serializeNodeWithId(
     // TODO: dev only
     console.warn(n, 'not serialized');
     return null;
-  } else if (slimDOM &&
-      ((_serializedNode.type === NodeType.Element && _serializedNode.tagName == 'script')
-       || _serializedNode.type === NodeType.Comment)) {
-    (n as INode).__sn = {id: -2, ignored: true};
-    return null;
   }
 
   let id;
   // Try to reuse the previous id
   if ('__sn' in n) {
     id = n.__sn.id;
+  } else if (slimDOM &&
+      ((_serializedNode.type === NodeType.Element && _serializedNode.tagName == 'script')
+       || _serializedNode.type === NodeType.Comment)) {
+    id = -2;  // mark as ignored
   } else {
     id = genId();
   }
   const serializedNode = Object.assign(_serializedNode, { id });
   (n as INode).__sn = serializedNode;
+  if (id === -2) {
+    return null;  // slimDOM
+  }
   map[id] = n as INode;
   let recordChild = !skipChild;
   if (serializedNode.type === NodeType.Element) {

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -11,6 +11,8 @@ import {
 let _id = 1;
 const tagNameRegex = RegExp('[^a-z1-6-_]');
 
+export const IGNORED_NODE = -2;
+
 function genId(): number {
   return _id++;
 }
@@ -362,13 +364,13 @@ export function serializeNodeWithId(
           !_serializedNode.textContent.replace(/^\s+|\s+$/gm,'').length
          )
   )) {
-    id = -2;  // mark as ignored
+    id = IGNORED_NODE;
   } else {
     id = genId();
   }
   const serializedNode = Object.assign(_serializedNode, { id });
   (n as INode).__sn = serializedNode;
-  if (id === -2) {
+  if (id === IGNORED_NODE) {
     return null;  // slimDOM
   }
   map[id] = n as INode;

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,3 +87,9 @@ export type MaskInputOptions = Partial<{
   textarea: boolean;
   select: boolean;
 }>;
+
+export type SlimDOMOptions = Partial<{
+  script: boolean;
+  comment: boolean;
+  headWhitespace: boolean;
+}>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,5 +91,12 @@ export type MaskInputOptions = Partial<{
 export type SlimDOMOptions = Partial<{
   script: boolean;
   comment: boolean;
+  headFavicon: boolean;
   headWhitespace: boolean;
+  headMetaDescKeywords: boolean;
+  headMetaSocial: boolean;
+  headMetaRobots: boolean;
+  headMetaHttpEquiv: boolean;
+  headMetaAuthorship: boolean;
+  headMetaVerification: boolean;
 }>;


### PR DESCRIPTION
unnecessary in terms of replay

 - <script> tags in the <head> take up unnecessary storage space and are often injected semi randomly to become a source of unnecessary variation between recordings of the same thing
 - comment tags can be stripped out without affecting display
 - future: this option could also turn on more aggressive stripping, e.g. elements that are hidden by CSS (assuming we can handle them becoming visible after mutation events)