### PR TITLE
Expand what is considered to be a valid tag name to include underscores

### DIFF
--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -9,7 +9,7 @@ import {
 } from './types';
 
 let _id = 1;
-const symbolAndNumberRegex = RegExp('[^a-z1-6-]');
+const tagNameRegex = RegExp('[^a-z1-6-_]');
 
 function genId(): number {
   return _id++;
@@ -18,7 +18,7 @@ function genId(): number {
 function getValidTagName(tagName: string): string {
   const processedTagName = tagName.toLowerCase().trim();
 
-  if (symbolAndNumberRegex.test(processedTagName)) {
+  if (tagNameRegex.test(processedTagName)) {
     // if the tag name is odd and we cannot extract
     // anything from the string, then we return a
     // generic div


### PR DESCRIPTION
 - was making this change for `<wix-image>` on Wix websites, but discovered after that this has already been done in e4593ff76d90e2519abe66186c38c0c2c473cd01
 - have tested document.createElement('wix-image') and document.createElement('foo_bar'), but can't find a canonical source for what is allowed in tag names.
 - this restriction was originally introduced in #150 to prevent document.createElement('alt=""') i.e. a very malformed tag name