### PR TITLE
Add ability to reset the mapping id, to facilitate destructor in rrweb

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import snapshot, {
   serializeNodeWithId,
   transformAttribute,
   visitSnapshot,
+  cleanupSnapshot,
   IGNORED_NODE,
 } from './snapshot';
 import rebuild, { buildNodeWithSN, addHoverClass } from './rebuild';
@@ -15,5 +16,6 @@ export {
   addHoverClass,
   transformAttribute,
   visitSnapshot,
+  cleanupSnapshot,
   IGNORED_NODE,
 };

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -573,4 +573,9 @@ export function visitSnapshot(
   walk(node);
 }
 
+export function cleanupSnapshot() {
+  // allow a new recording to start numbering nodes from scratch
+  _id = 1;
+}
+
 export default snapshot;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,4 +1,4 @@
-import snapshot, { serializeNodeWithId, transformAttribute, visitSnapshot, IGNORED_NODE } from './snapshot';
+import snapshot, { serializeNodeWithId, transformAttribute, visitSnapshot, IGNORED_NODE, cleanupSnapshot } from './snapshot';
 import rebuild, { buildNodeWithSN, addHoverClass } from './rebuild';
 export * from './types';
-export { snapshot, serializeNodeWithId, rebuild, buildNodeWithSN, addHoverClass, transformAttribute, visitSnapshot, IGNORED_NODE, };
+export { snapshot, serializeNodeWithId, rebuild, buildNodeWithSN, addHoverClass, transformAttribute, visitSnapshot, IGNORED_NODE, cleanupSnapshot, };

--- a/typings/snapshot.d.ts
+++ b/typings/snapshot.d.ts
@@ -6,4 +6,5 @@ export declare function transformAttribute(doc: Document, name: string, value: s
 export declare function serializeNodeWithId(n: Node | INode, doc: Document, map: idNodeMap, blockClass: string | RegExp, skipChild?: boolean, inlineStylesheet?: boolean, maskInputOptions?: MaskInputOptions, slimDOMOptions?: SlimDOMOptions, recordCanvas?: boolean, preserveWhiteSpace?: boolean): serializedNodeWithId | null;
 declare function snapshot(n: Document, blockClass: string | RegExp | undefined, inlineStylesheet: boolean | undefined, maskAllInputsOrOptions: boolean | MaskInputOptions, slimDOMSensibleOrOptions: boolean | SlimDOMOptions, recordCanvas?: boolean): [serializedNodeWithId | null, idNodeMap];
 export declare function visitSnapshot(node: serializedNodeWithId, onVisit: (node: serializedNodeWithId) => unknown): void;
+export declare function cleanupSnapshot(): void;
 export default snapshot;


### PR DESCRIPTION
a new rrwebRecord.stop() will call cleanupSnapshot