### PR TITLE
Prefer a map and a join

### DIFF
--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -35,10 +35,7 @@ function getCssRulesString(s: CSSStyleSheet): string | null {
   try {
     const rules = s.rules || s.cssRules;
     return rules
-      ? Array.from(rules).reduce(
-          (prev, cur) => prev + getCssRuleString(cur),
-          '',
-        )
+      ? Array.from(rules).map(getCssRuleString).join('')
       : null;
   } catch (error) {
     return null;


### PR DESCRIPTION
As I feel it's easier to understand, and I found a case in the wild where `Array.prototype.reduce` was overwritten (which admittedly is also a danger with `map`)