### PR TITLE
feat: 修改在svg , xlink:href 相对路径改为绝对路径

### DIFF
--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -151,7 +151,7 @@ export function transformAttribute(
   value: string,
 ): string {
   // relative path in attribute
-  if (name === 'src' || (name === 'href' && value)) {
+  if (name === 'src' || ((name === 'href' || name === 'xlink:href') && value)) {
     return absoluteToDoc(doc, value);
   } else if (name === 'srcset' && value) {
     return getAbsoluteSrcsetString(doc, value);


### PR DESCRIPTION
svg 情况下 xlink:href 引用相对路径图片，在播放端会因为路径问题，加载不了图片。改成绝对路径使图片加载正常