### PR TITLE
svg xlink:href 路径问题

### DIFF
--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -151,7 +151,7 @@ export function transformAttribute(
   value: string,
 ): string {
   // relative path in attribute
-  if (name === 'src' || (name === 'href' && value)) {
+  if (name === 'src' || ((name === 'href' || name === 'xlink:href') && value)) {
     return absoluteToDoc(doc, value);
   } else if (name === 'srcset' && value) {
     return getAbsoluteSrcsetString(doc, value);

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -151,7 +151,7 @@ export function transformAttribute(
   value: string,
 ): string {
   // relative path in attribute
-  if (name === 'src' || ((name === 'href' || name === 'xlink:href') && value)) {
+  if (name === 'src' || (name === 'href' && value)) {
     return absoluteToDoc(doc, value);
   } else if (name === 'srcset' && value) {
     return getAbsoluteSrcsetString(doc, value);

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -151,7 +151,7 @@ export function transformAttribute(
   value: string,
 ): string {
   // relative path in attribute
-  if (name === 'src' || (name === 'href' && value) || (name === 'xlink:href' && value)) {
+  if (name === 'src' || ((name === 'href' || name === 'xlink:href') && value)) {
     return absoluteToDoc(doc, value);
   } else if (name === 'srcset' && value) {
     return getAbsoluteSrcsetString(doc, value);

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -151,7 +151,7 @@ export function transformAttribute(
   value: string,
 ): string {
   // relative path in attribute
-  if (name === 'src' || ((name === 'href' || name === 'xlink:href') && value)) {
+  if (name === 'src' || (name === 'href' && value) || (name === 'xlink:href' && value)) {
     return absoluteToDoc(doc, value);
   } else if (name === 'srcset' && value) {
     return getAbsoluteSrcsetString(doc, value);


### PR DESCRIPTION
修改在svg 中 xlink:href 引用相对路径图片，在播放端加载失败问题。 修改为绝对路径，解决此问题