### PR TITLE
Was failing to detect a valid data: url

### DIFF
--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -65,7 +65,7 @@ function extractOrigin(url: string): string {
 
 const URL_IN_CSS_REF = /url\((?:(')([^']*)'|(")([^"]*)"|([^)]*))\)/gm;
 const RELATIVE_PATH = /^(?!www\.|(?:http|ftp)s?:\/\/|[A-Za-z]:\\|\/\/).*/;
-const DATA_URI = /^(data:)([\w\/\+\-]+);(charset=[\w-]+|base64|utf-?8).*,(.*)/i;
+const DATA_URI = /^data:/i;
 export function absoluteToStylesheet(
   cssText: string | null,
   href: string,


### PR DESCRIPTION
Was failing to detect the following valid (in terms of cross browser rendering) data url:

url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='10' width='10' viewBox='0 0 10 10' stroke='black'%3E%3Cpath d='m2 1h2v2' /%3E%3C/svg%3E")

So I just simplified the regex for data urls as we are not using all the charset related stuff anyway.