### PR TITLE
using for loop instead of forEach in element classlists

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.6",
   "description": "rrweb's component to take a snapshot of DOM, aka DOM serializer",
   "scripts": {
+    "prepare": "npm run bundle",
     "test": "cross-env TS_NODE_CACHE=false TS_NODE_FILES=true mocha -r ts-node/register test/**/*.ts",
     "bundle": "rollup --config",
     "typings": "tsc -d --declarationDir typings"

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -183,11 +183,12 @@ export function _isBlockedElement(
       return true;
     }
   } else {
-    element.classList.forEach((className) => {
+    for (let eIndex = 0; eIndex < element.classList.length; eIndex++) {
+      const className = element.classList[eIndex];
       if (blockClass.test(className)) {
         return true;
       }
-    });
+    }
   }
   if (blockSelector) {
     return element.matches(blockSelector);


### PR DESCRIPTION
using a forEach loop does not allow us to return early from iterating all the elements in the classlist. We need to use the good old for loop to do so. This bug broke all css blocking.

The prepare script allows us to pull from github as a npm dep without having to commit the bundled result.