### PR TITLE
Valid tag names can include any digit [0-9]

### DIFF
--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -10,7 +10,7 @@ import {
 } from './types';
 
 let _id = 1;
-const tagNameRegex = RegExp('[^a-z1-6-_]');
+const tagNameRegex = RegExp('[^a-z0-9-_]');
 
 export const IGNORED_NODE = -2;
 


### PR DESCRIPTION
- This change will allow HTML tag names that include any digit eg. `<extension-v182>`.
- The current regex (created in  #28) was updated to allows tags with the digits [1-6] and therefore only supports `h` tags eg. `<h1> ... <h6>`.
- This change is non-breaking.

