### PR TITLE
Support very obsolete table background images

### DIFF
--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -158,11 +158,14 @@ function getHref() {
 
 export function transformAttribute(
   doc: Document,
+  tagName: string,
   name: string,
   value: string,
 ): string {
   // relative path in attribute
   if (name === 'src' || ((name === 'href' || name === 'xlink:href') && value)) {
+    return absoluteToDoc(doc, value);
+  } else if (name === 'background' && value && (tagName === 'table' || tagName == 'td' || tagName == 'th')) {
     return absoluteToDoc(doc, value);
   } else if (name === 'srcset' && value) {
     return getAbsoluteSrcsetString(doc, value);
@@ -294,7 +297,7 @@ function serializeNode(
       const tagName = getValidTagName(n as HTMLElement);
       let attributes: attributes = {};
       for (const { name, value } of Array.from((n as HTMLElement).attributes)) {
-        attributes[name] = transformAttribute(doc, name, value);
+        attributes[name] = transformAttribute(doc, tagName, name, value);
       }
       // remote css
       if (tagName === 'link' && inlineStylesheet) {


### PR DESCRIPTION
Found an example in the wild of the deprecated pre-css way of adding a background image to tables or table cells.

Found some documentation here: https://html.com/attributes/td-background/

This is very old/obsolete markup style so I understand if you don't wish to pollute the master branch with this change!