### PR TITLE
Speed up addHoverClass on large stylesheets

### DIFF
--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -83,7 +83,8 @@ function unique(arr: string[]): string[] {
   return arr;
 }
 
-const HOVER_SELECTOR = /([^\\]):hover/g;
+const HOVER_SELECTOR = /([^\\]):hover/;
+const HOVER_SELECTOR_GLOBAL = new RegExp(HOVER_SELECTOR, 'g');
 export function addHoverClass(cssText: string): string {
   const ast = parse(cssText, {
     silent: true,
@@ -108,6 +109,7 @@ export function addHoverClass(cssText: string): string {
 
   const selectorMatcher = new RegExp(
     unique(selectors)
+      .sort((a, b) => b.length - a.length)
       .map((selector) => {
         return escapeRegExp(selector);
       })
@@ -116,8 +118,8 @@ export function addHoverClass(cssText: string): string {
   );
 
   return cssText.replace(selectorMatcher, (selector) => {
-    const newSelector = selector.replace(HOVER_SELECTOR, '$1.\\:hover');
-    return selector + ', ' + newSelector;
+    const newSelector = selector.replace(HOVER_SELECTOR_GLOBAL, '$1.\\:hover');
+    return `${selector}, ${newSelector}`;
   });
 }
 

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -62,27 +62,6 @@ function escapeRegExp(string: string) {
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
 }
 
-// based on https://github.com/jonschlinkert/array-unique
-function unique(arr: string[]): string[] {
-  if (!Array.isArray(arr)) {
-    throw new TypeError('array-unique expects an array.');
-  }
-
-  const len = arr.length;
-  let i = -1;
-
-  while (i++ < len) {
-    let j = i + 1;
-
-    for (; j < arr.length; ++j) {
-      if (arr[i] === arr[j]) {
-        arr.splice(j--, 1);
-      }
-    }
-  }
-  return arr;
-}
-
 const HOVER_SELECTOR = /([^\\]):hover/;
 const HOVER_SELECTOR_GLOBAL = new RegExp(HOVER_SELECTOR, 'g');
 export function addHoverClass(cssText: string): string {
@@ -108,7 +87,8 @@ export function addHoverClass(cssText: string): string {
   if (selectors.length === 0) return cssText;
 
   const selectorMatcher = new RegExp(
-    unique(selectors)
+    selectors
+      .filter((selector, index) => selectors.indexOf(selector) === index)
       .sort((a, b) => b.length - a.length)
       .map((selector) => {
         return escapeRegExp(selector);

--- a/test/rebuild.test.ts
+++ b/test/rebuild.test.ts
@@ -24,6 +24,13 @@ describe('add hover class to hover selector related rules', () => {
     );
   });
 
+  it('can add hover class when there is a multi selector with the same prefix', () => {
+    const cssText = '.a:hover, .a:hover::after { color: white }';
+    expect(addHoverClass(cssText)).to.equal(
+      '.a:hover, .a.\\:hover, .a:hover::after, .a.\\:hover::after { color: white }',
+    );
+  });
+
   it('can add hover class when :hover is not the end of selector', () => {
     const cssText = 'div:hover::after { color: white }';
     expect(addHoverClass(cssText)).to.equal(


### PR DESCRIPTION
Multi-megabyte stylesheets were incredibly slow with addHoverClass. I was able to bring that back by >90% on large stylesheets at a negligible cost on tiny stylesheets.

Results included below:
```
Running "4.1M stylesheet" suite...

  existingAddHoverClass:
    0 ops/s, ±0.90%   | slowest, 100% slower

  newAddHoverClass:
    2 ops/s, ±2.98%   | fastest

Finished 2 cases!
  Fastest: newAddHoverClass
  Slowest: existingAddHoverClass
```
```
Running "248K stylesheet" suite...

  existingAddHoverClass:
    56 ops/s, ±2.10%   | slowest, 32.53% slower

  newAddHoverClass:
    83 ops/s, ±1.86%   | fastest

Finished 2 cases!
  Fastest: newAddHoverClass
  Slowest: existingAddHoverClass
```
```
Running "105B stylesheet" suite...

  existingAddHoverClass:
    22 031 ops/s, ±2.32%   | fastest

  newAddHoverClass:
    21 493 ops/s, ±3.22%   | slowest, 2.44% slower

Finished 2 cases!
  Fastest: existingAddHoverClass
  Slowest: newAddHoverClass
```
Benchmark ran in node.js on a MacBook Pro (16-inch, 2019), 2,3 GHz 8-Core Intel Core i9.
Similar results found when running tests in Safari and Chrome.
[Visual charts of these benchmarks: `results.zip`](https://github.com/rrweb-io/rrweb-snapshot/files/6303786/results.zip)
