### PR TITLE
Update tagname regex to support tag names with namespaces

### DIFF
--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -12,7 +12,7 @@ import {
 import { isElement, isShadowRoot } from './utils';
 
 let _id = 1;
-const tagNameRegex = RegExp('[^a-z0-9-_]');
+const tagNameRegex = RegExp('[^a-z0-9-_:]');
 
 export const IGNORED_NODE = -2;
 


### PR DESCRIPTION
SVG content embedded in HTML can include a namespace within the tagname: `<svg:svg ... >`. In particular, SVG content generated by pdf.js will include namespaces. The original regular expression would not validate these and convert them to div tags, so the replay would not properly render the SVG content.  Updating the regular expression allows rrweb to properly serialize and recreate SVG content.