### PR TITLE
Fix iframe event order: https://github.com/rrweb-io/rrweb/issues/567

### DIFF
--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -327,7 +327,9 @@ function onceIframeLoaded(
     iframeEl.src === blankUrl ||
     iframeEl.src === ''
   ) {
-    listener();
+    // iframe was already loaded, make sure we wait to trigger the listener
+    // till _after_ the mutation that found this iframe has had time to process
+    setTimeout(listener, 0);
     return;
   }
   // use default listener


### PR DESCRIPTION
Better alternative to the first fix in: https://github.com/rrweb-io/rrweb/pull/568 (now that PR just contains fixed tests).
This PR fixes: https://github.com/rrweb-io/rrweb/issues/567

Fix:
For iframes who's contents are instantly available we now wait till mutation is processed before triggering the `onceIframeLoaded` listener and adding a mutation with the contents of the iframe.

Problem:
Before this PR iframe's contents would get added in a mutation before the iframe itself was added in a mutation.