### PR TITLE
Move `maskInputValue` to rrweb-snapshot from rrweb and apply `maskInputFn` in `serializeNode`

### DIFF
--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -8,8 +8,9 @@ import {
   MaskInputOptions,
   SlimDOMOptions,
   MaskTextFn,
+  MaskInputFn,
 } from './types';
-import { isElement, isShadowRoot } from './utils';
+import { isElement, isShadowRoot, maskInputValue } from './utils';
 
 let _id = 1;
 const tagNameRegex = RegExp('[^a-z0-9-_:]');
@@ -345,6 +346,7 @@ function serializeNode(
     inlineStylesheet: boolean;
     maskInputOptions: MaskInputOptions;
     maskTextFn: MaskTextFn | undefined;
+    maskInputFn: MaskInputFn | undefined;
     recordCanvas: boolean;
   },
 ): serializedNode | false {
@@ -357,12 +359,13 @@ function serializeNode(
     inlineStylesheet,
     maskInputOptions = {},
     maskTextFn,
+    maskInputFn,
     recordCanvas,
   } = options;
   // Only record root id when document object is not the base document
   let rootId: number | undefined;
-  if (((doc as unknown) as INode).__sn) {
-    const docId = ((doc as unknown) as INode).__sn.id;
+  if ((doc as unknown as INode).__sn) {
+    const docId = (doc as unknown as INode).__sn.id;
     rootId = docId === 1 ? undefined : docId;
   }
   switch (n.nodeType) {
@@ -438,11 +441,13 @@ function serializeNode(
           attributes.type !== 'button' &&
           value
         ) {
-          attributes.value =
-            maskInputOptions[attributes.type as keyof MaskInputOptions] ||
-            maskInputOptions[tagName as keyof MaskInputOptions]
-              ? '*'.repeat(value.length)
-              : value;
+          attributes.value = maskInputValue({
+            type: attributes.type,
+            tagName,
+            value,
+            maskInputOptions,
+            maskInputFn,
+          });
         } else if ((n as HTMLInputElement).checked) {
           attributes.checked = (n as HTMLInputElement).checked;
         }
@@ -644,6 +649,7 @@ export function serializeNodeWithId(
     inlineStylesheet: boolean;
     maskInputOptions?: MaskInputOptions;
     maskTextFn: MaskTextFn | undefined;
+    maskInputFn: MaskInputFn | undefined;
     slimDOMOptions: SlimDOMOptions;
     recordCanvas?: boolean;
     preserveWhiteSpace?: boolean;
@@ -663,6 +669,7 @@ export function serializeNodeWithId(
     inlineStylesheet = true,
     maskInputOptions = {},
     maskTextFn,
+    maskInputFn,
     slimDOMOptions,
     recordCanvas = false,
     onSerialize,
@@ -679,6 +686,7 @@ export function serializeNodeWithId(
     inlineStylesheet,
     maskInputOptions,
     maskTextFn,
+    maskInputFn,
     recordCanvas,
   });
   if (!_serializedNode) {
@@ -741,6 +749,7 @@ export function serializeNodeWithId(
       inlineStylesheet,
       maskInputOptions,
       maskTextFn,
+      maskInputFn,
       slimDOMOptions,
       recordCanvas,
       preserveWhiteSpace,
@@ -791,6 +800,7 @@ export function serializeNodeWithId(
             inlineStylesheet,
             maskInputOptions,
             maskTextFn,
+            maskInputFn,
             slimDOMOptions,
             recordCanvas,
             preserveWhiteSpace,
@@ -821,6 +831,7 @@ function snapshot(
     inlineStylesheet?: boolean;
     maskAllInputs?: boolean | MaskInputOptions;
     maskTextFn?: MaskTextFn;
+    maskInputFn?: MaskTextFn;
     slimDOM?: boolean | SlimDOMOptions;
     recordCanvas?: boolean;
     preserveWhiteSpace?: boolean;
@@ -838,6 +849,7 @@ function snapshot(
     recordCanvas = false,
     maskAllInputs = false,
     maskTextFn,
+    maskInputFn,
     slimDOM = false,
     preserveWhiteSpace,
     onSerialize,
@@ -900,6 +912,7 @@ function snapshot(
       inlineStylesheet,
       maskInputOptions,
       maskTextFn,
+      maskInputFn,
       slimDOMOptions,
       recordCanvas,
       preserveWhiteSpace,

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,3 +108,4 @@ export type SlimDOMOptions = Partial<{
 }>;
 
 export type MaskTextFn = (text: string) => string;
+export type MaskInputFn = (text: string) => string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { INode } from './types';
+import { INode, MaskInputFn, MaskInputOptions } from './types';
 
 export function isElement(n: Node | INode): n is Element {
   return n.nodeType === n.ELEMENT_NODE;
@@ -7,4 +7,31 @@ export function isElement(n: Node | INode): n is Element {
 export function isShadowRoot(n: Node): n is ShadowRoot {
   const host: Element | null = (n as ShadowRoot)?.host;
   return Boolean(host && host.shadowRoot && host.shadowRoot === n);
+}
+
+export function maskInputValue({
+  maskInputOptions,
+  tagName,
+  type,
+  value,
+  maskInputFn,
+}: {
+  maskInputOptions: MaskInputOptions;
+  tagName: string;
+  type: string | number | boolean | null;
+  value: string | null;
+  maskInputFn?: MaskInputFn;
+}): string {
+  let text = value || '';
+  if (
+    maskInputOptions[tagName.toLowerCase() as keyof MaskInputOptions] ||
+    maskInputOptions[type as keyof MaskInputOptions]
+  ) {
+    if (maskInputFn) {
+      text = maskInputFn(text);
+    } else {
+      text = '*'.repeat(text.length);
+    }
+  }
+  return text;
 }

--- a/typings/snapshot.d.ts
+++ b/typings/snapshot.d.ts
@@ -1,4 +1,4 @@
-import { serializedNodeWithId, INode, idNodeMap, MaskInputOptions, SlimDOMOptions, MaskTextFn } from './types';
+import { serializedNodeWithId, INode, idNodeMap, MaskInputOptions, SlimDOMOptions, MaskTextFn, MaskInputFn } from './types';
 export declare const IGNORED_NODE = -2;
 export declare function absoluteToStylesheet(cssText: string | null, href: string): string;
 export declare function absoluteToDoc(doc: Document, attributeValue: string): string;
@@ -16,6 +16,7 @@ export declare function serializeNodeWithId(n: Node | INode, options: {
     inlineStylesheet: boolean;
     maskInputOptions?: MaskInputOptions;
     maskTextFn: MaskTextFn | undefined;
+    maskInputFn: MaskInputFn | undefined;
     slimDOMOptions: SlimDOMOptions;
     recordCanvas?: boolean;
     preserveWhiteSpace?: boolean;
@@ -31,6 +32,7 @@ declare function snapshot(n: Document, options?: {
     inlineStylesheet?: boolean;
     maskAllInputs?: boolean | MaskInputOptions;
     maskTextFn?: MaskTextFn;
+    maskInputFn?: MaskTextFn;
     slimDOM?: boolean | SlimDOMOptions;
     recordCanvas?: boolean;
     preserveWhiteSpace?: boolean;

--- a/typings/types.d.ts
+++ b/typings/types.d.ts
@@ -88,3 +88,4 @@ export declare type SlimDOMOptions = Partial<{
     headMetaVerification: boolean;
 }>;
 export declare type MaskTextFn = (text: string) => string;
+export declare type MaskInputFn = (text: string) => string;

--- a/typings/utils.d.ts
+++ b/typings/utils.d.ts
@@ -1,3 +1,10 @@
-import { INode } from './types';
+import { INode, MaskInputFn, MaskInputOptions } from './types';
 export declare function isElement(n: Node | INode): n is Element;
 export declare function isShadowRoot(n: Node): n is ShadowRoot;
+export declare function maskInputValue({ maskInputOptions, tagName, type, value, maskInputFn, }: {
+    maskInputOptions: MaskInputOptions;
+    tagName: string;
+    type: string | number | boolean | null;
+    value: string | null;
+    maskInputFn?: MaskInputFn;
+}): string;


### PR DESCRIPTION
Moves `maskInputValue` from rrweb into rrweb-snapshot: [More info](https://github.com/rrweb-io/rrweb/pull/602#discussion_r660434998)

Also applies `maskInputFn` option to masked input values in `serializeNode`