### PR TITLE
Cache addHoverClass as it is quite expensive

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,11 @@ import snapshot, {
   needMaskingText,
   IGNORED_NODE,
 } from './snapshot';
-import rebuild, { buildNodeWithSN, addHoverClass } from './rebuild';
+import rebuild, {
+  buildNodeWithSN,
+  addHoverClass,
+  createCache,
+} from './rebuild';
 export * from './types';
 export * from './utils';
 
@@ -16,6 +20,7 @@ export {
   rebuild,
   buildNodeWithSN,
   addHoverClass,
+  createCache,
   transformAttribute,
   visitSnapshot,
   cleanupSnapshot,

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -6,6 +6,7 @@ import {
   elementNode,
   idNodeMap,
   INode,
+  BuildCache,
 } from './types';
 import { isElement } from './utils';
 
@@ -64,9 +65,8 @@ function escapeRegExp(str: string) {
 
 const HOVER_SELECTOR = /([^\\]):hover/;
 const HOVER_SELECTOR_GLOBAL = new RegExp(HOVER_SELECTOR, 'g');
-const cachedStyles = new Map<string, string>();
-export function addHoverClass(cssText: string): string {
-  const cachedStyle = cachedStyles.get(cssText);
+export function addHoverClass(cssText: string, cache?: BuildCache): string {
+  const cachedStyle = cache?.stylesWithHoverClass.get(cssText);
   if (cachedStyle) return cachedStyle;
 
   const ast = parse(cssText, {
@@ -107,8 +107,15 @@ export function addHoverClass(cssText: string): string {
     const newSelector = selector.replace(HOVER_SELECTOR_GLOBAL, '$1.\\:hover');
     return `${selector}, ${newSelector}`;
   });
-  cachedStyles.set(cssText, result);
+  cache?.stylesWithHoverClass.set(cssText, result);
   return result;
+}
+
+export function createCache(): BuildCache {
+  const stylesWithHoverClass: Map<string, string> = new Map();
+  return {
+    stylesWithHoverClass,
+  };
 }
 
 function buildNode(
@@ -116,9 +123,10 @@ function buildNode(
   options: {
     doc: Document;
     hackCss: boolean;
+    cache?: BuildCache;
   },
 ): Node | null {
-  const { doc, hackCss } = options;
+  const { doc, hackCss, cache } = options;
   switch (n.type) {
     case NodeType.Document:
       return doc.implementation.createDocument(null, '', null);
@@ -149,7 +157,7 @@ function buildNode(
           const isRemoteOrDynamicCss =
             tagName === 'style' && name === '_cssText';
           if (isRemoteOrDynamicCss && hackCss) {
-            value = addHoverClass(value);
+            value = addHoverClass(value, cache);
           }
           if (isTextarea || isRemoteOrDynamicCss) {
             const child = doc.createTextNode(value);
@@ -262,7 +270,9 @@ function buildNode(
       return node;
     case NodeType.Text:
       return doc.createTextNode(
-        n.isStyle && hackCss ? addHoverClass(n.textContent) : n.textContent,
+        n.isStyle && hackCss
+          ? addHoverClass(n.textContent, cache)
+          : n.textContent,
       );
     case NodeType.CDATA:
       return doc.createCDATASection(n.textContent);
@@ -281,10 +291,18 @@ export function buildNodeWithSN(
     skipChild?: boolean;
     hackCss: boolean;
     afterAppend?: (n: INode) => unknown;
+    cache?: BuildCache;
   },
 ): INode | null {
-  const { doc, map, skipChild = false, hackCss = true, afterAppend } = options;
-  let node = buildNode(n, { doc, hackCss });
+  const {
+    doc,
+    map,
+    skipChild = false,
+    hackCss = true,
+    afterAppend,
+    cache,
+  } = options;
+  let node = buildNode(n, { doc, hackCss, cache });
   if (!node) {
     return null;
   }
@@ -316,6 +334,7 @@ export function buildNodeWithSN(
         skipChild: false,
         hackCss,
         afterAppend,
+        cache,
       });
       if (!childNode) {
         console.warn('Failed to rebuild', childN);
@@ -375,9 +394,10 @@ function rebuild(
     onVisit?: (node: INode) => unknown;
     hackCss?: boolean;
     afterAppend?: (n: INode) => unknown;
+    cache?: BuildCache;
   },
 ): [Node | null, idNodeMap] {
-  const { doc, onVisit, hackCss = true, afterAppend } = options;
+  const { doc, onVisit, hackCss = true, afterAppend, cache } = options;
   const idNodeMap: idNodeMap = {};
   const node = buildNodeWithSN(n, {
     doc,
@@ -385,6 +405,7 @@ function rebuild(
     skipChild: false,
     hackCss,
     afterAppend,
+    cache,
   });
   visit(idNodeMap, (visitedNode) => {
     if (onVisit) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,3 +111,7 @@ export type MaskTextFn = (text: string) => string;
 export type MaskInputFn = (text: string) => string;
 
 export type KeepIframeSrcFn = (src: string) => boolean;
+
+export type BuildCache = {
+  stylesWithHoverClass: Map<string, string>;
+};

--- a/test/rebuild.test.ts
+++ b/test/rebuild.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import 'mocha';
 import { expect } from 'chai';
-import { addHoverClass } from '../src/rebuild';
+import { addHoverClass, createCache } from '../src/rebuild';
 
 function getDuration(hrtime: [number, number]) {
   const [seconds, nanoseconds] = hrtime;
@@ -67,7 +67,7 @@ describe('add hover class to hover selector related rules', () => {
     expect(duration).to.below(100);
   });
 
-  it('should be a lot faster to add a hover class to a previously processed css string', () => {
+  it('should be a lot faster to add a hover class to a previously processed css string when using a cache', () => {
     const factor = 100;
 
     let cssText = fs.readFileSync(
@@ -75,18 +75,14 @@ describe('add hover class to hover selector related rules', () => {
       'utf8',
     );
 
-    // make sure this time we run addHoverClass it isn't already in cache
-    cssText = `
-      ${cssText}
-      //cache-bust: ${Date.now()}
-    `;
+    const cache = createCache();
 
     const start = process.hrtime();
-    addHoverClass(cssText);
+    addHoverClass(cssText, cache);
     const end = process.hrtime(start);
 
     const cachedStart = process.hrtime();
-    addHoverClass(cssText);
+    addHoverClass(cssText, cache);
     const cachedEnd = process.hrtime(cachedStart);
 
     expect(getDuration(cachedEnd) * factor).to.below(getDuration(end));

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,5 +1,5 @@
 import snapshot, { serializeNodeWithId, transformAttribute, visitSnapshot, cleanupSnapshot, needMaskingText, IGNORED_NODE } from './snapshot';
-import rebuild, { buildNodeWithSN, addHoverClass } from './rebuild';
+import rebuild, { buildNodeWithSN, addHoverClass, createCache } from './rebuild';
 export * from './types';
 export * from './utils';
-export { snapshot, serializeNodeWithId, rebuild, buildNodeWithSN, addHoverClass, transformAttribute, visitSnapshot, cleanupSnapshot, needMaskingText, IGNORED_NODE, };
+export { snapshot, serializeNodeWithId, rebuild, buildNodeWithSN, addHoverClass, createCache, transformAttribute, visitSnapshot, cleanupSnapshot, needMaskingText, IGNORED_NODE, };

--- a/typings/rebuild.d.ts
+++ b/typings/rebuild.d.ts
@@ -1,16 +1,19 @@
-import { serializedNodeWithId, idNodeMap, INode } from './types';
-export declare function addHoverClass(cssText: string): string;
+import { serializedNodeWithId, idNodeMap, INode, BuildCache } from './types';
+export declare function addHoverClass(cssText: string, cache?: BuildCache): string;
+export declare function createCache(): BuildCache;
 export declare function buildNodeWithSN(n: serializedNodeWithId, options: {
     doc: Document;
     map: idNodeMap;
     skipChild?: boolean;
     hackCss: boolean;
     afterAppend?: (n: INode) => unknown;
+    cache?: BuildCache;
 }): INode | null;
 declare function rebuild(n: serializedNodeWithId, options: {
     doc: Document;
     onVisit?: (node: INode) => unknown;
     hackCss?: boolean;
     afterAppend?: (n: INode) => unknown;
+    cache?: BuildCache;
 }): [Node | null, idNodeMap];
 export default rebuild;

--- a/typings/types.d.ts
+++ b/typings/types.d.ts
@@ -90,3 +90,6 @@ export declare type SlimDOMOptions = Partial<{
 export declare type MaskTextFn = (text: string) => string;
 export declare type MaskInputFn = (text: string) => string;
 export declare type KeepIframeSrcFn = (src: string) => boolean;
+export declare type BuildCache = {
+    stylesWithHoverClass: Map<string, string>;
+};


### PR DESCRIPTION
Problem:
`addHoverClass` is one of the most CPU intensive things we do when rebuilding a snapshot. And especially when scrubbing backwards or browsing a recording by clicking around on the timeline `addHoverClass` gets repeatedly called.

Solution:
This PR caches the results of `addHoverClass` so they only have to be calculated once and after that they are fast.